### PR TITLE
Set minimum required windows version to XP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,7 @@ if(MSVC)
 endif()
 
 if(WIN32)
+  add_compile_definitions(WINVER=0x0501 _WIN32_WINNT=0x0501)
   if(MINGW)
     set(SO${GUI}_DEFAULT_SHARED_POSTFIX "")
     set(SO${GUI}_DEFAULT_STATIC_POSTFIX "")


### PR DESCRIPTION
If the compiler supports the code generation for the platform (XP, Vista, ...) SoWin can run on any of them not only on the platform it was compiled on.